### PR TITLE
use // to prevent mixed content warnings on https

### DIFF
--- a/mysite/code/Page.php
+++ b/mysite/code/Page.php
@@ -30,7 +30,7 @@ class Page_Controller extends ContentController {
 
 	public function init() {
 		parent::init();
-		Requirements::css("http://fonts.googleapis.com/css?family=Raleway:300,500,900%7COpen+Sans:400,700,400italic");
+		Requirements::css("//fonts.googleapis.com/css?family=Raleway:300,500,900%7COpen+Sans:400,700,400italic");
 		Requirements::css("{$this->ThemeDir()}/css/bootstrap.min.css");
 		Requirements::css("{$this->ThemeDir()}/css/style.css");
 

--- a/themes/one-ring/templates/Includes/Footer.ss
+++ b/themes/one-ring/templates/Includes/Footer.ss
@@ -21,19 +21,19 @@
 								<ul class="footer-listings">
 									<li>
 										<div class="image">
-											<a href="properties-detail.html"><img src="http://placehold.it/760x670" alt="" /></a>
+											<a href="properties-detail.html"><img src="//placehold.it/760x670" alt="" /></a>
 										</div>
 										<p><a href="properties-detail.html">Rhovanion</a></p>
 									</li>
 									<li>	
 										<div class="image">
-											<a href="properties-detail.html"><img src="http://placehold.it/760x670" alt="" /></a>
+											<a href="properties-detail.html"><img src="//placehold.it/760x670" alt="" /></a>
 										</div>
 										<p><a href="properties-detail.html">Eriador</a></p>
 									</li>
 									<li>
 										<div class="image">
-											<a href="properties-detail.html"><img src="http://placehold.it/760x670" alt="" /></a>
+											<a href="properties-detail.html"><img src="//placehold.it/760x670" alt="" /></a>
 										</div>
 										<p><a href="properties-detail.html">Bay of Belfalas</a></p>
 									</li>
@@ -43,19 +43,19 @@
 								<ul class="footer-listings">
 									<li>
 										<div class="image">
-											<a href="properties-detail.html"><img src="http://placehold.it/760x670" alt="" /></a>
+											<a href="properties-detail.html"><img src="//placehold.it/760x670" alt="" /></a>
 										</div>
 										<p><a href="properties-detail.html">Mordor</a></p>
 									</li>
 									<li>
 										<div class="image">
-											<a href="properties-detail.html"><img src="http://placehold.it/760x670" alt="" /></a>
+											<a href="properties-detail.html"><img src="//placehold.it/760x670" alt="" /></a>
 										</div>
 										<p><a href="properties-detail.html">Arnor</a></p>
 									</li>
 									<li>
 										<div class="image">
-											<a href="properties-detail.html"><img src="http://placehold.it/760x670" alt="" /></a>
+											<a href="properties-detail.html"><img src="//placehold.it/760x670" alt="" /></a>
 										</div>
 										<p><a href="properties-detail.html">Forlindon</a></p>
 									</li>

--- a/themes/one-ring/templates/Layout/ArticleHolder.ss
+++ b/themes/one-ring/templates/Layout/ArticleHolder.ss
@@ -167,7 +167,7 @@
 					<li class="col-md-12">
 						<div class="image">
 							<a href="blog-detail.html"></a>
-							<img src="http://placehold.it/100x100" alt="" />
+							<img src="//placehold.it/100x100" alt="" />
 						</div>
 						
 						<ul class="top-info">
@@ -179,7 +179,7 @@
 					<li class="col-md-12">
 						<div class="image">
 							<a href="blog-detail.html"></a>
-							<img src="http://placehold.it/100x100" alt="" />
+							<img src="//placehold.it/100x100" alt="" />
 						</div>
 						
 						<ul class="top-info">
@@ -191,7 +191,7 @@
 					<li class="col-md-12">
 						<div class="image">
 							<a href="blog-detail.html"></a>
-							<img src="http://placehold.it/100x100" alt="" />
+							<img src="//placehold.it/100x100" alt="" />
 						</div>
 						
 						<ul class="top-info">

--- a/themes/one-ring/templates/Layout/ArticlePage.ss
+++ b/themes/one-ring/templates/Layout/ArticlePage.ss
@@ -74,7 +74,7 @@
 						<% loop $Comments %>
 						<li>
 							<img src="$ThemeDir/images/comment-man.jpg" alt="" />
-							<div class="comment">								
+							<div class="comment">
 								<h3>$Name<small>$Created.Format('j F, Y')</small></h3>
 								<p>$Comment</p>
 							</div>
@@ -203,7 +203,7 @@
 					<li class="col-md-12">
 						<div class="image">
 							<a href="blog-detail.html"></a>
-							<img src="http://placehold.it/100x100" alt="" />
+							<img src="//placehold.it/100x100" alt="" />
 						</div>
 						
 						<ul class="top-info">
@@ -215,7 +215,7 @@
 					<li class="col-md-12">
 						<div class="image">
 							<a href="blog-detail.html"></a>
-							<img src="http://placehold.it/100x100" alt="" />
+							<img src="//placehold.it/100x100" alt="" />
 						</div>
 						
 						<ul class="top-info">
@@ -227,7 +227,7 @@
 					<li class="col-md-12">
 						<div class="image">
 							<a href="blog-detail.html"></a>
-							<img src="http://placehold.it/100x100" alt="" />
+							<img src="//placehold.it/100x100" alt="" />
 						</div>
 						
 						<ul class="top-info">

--- a/themes/one-ring/templates/Layout/HomePage.ss
+++ b/themes/one-ring/templates/Layout/HomePage.ss
@@ -9,14 +9,14 @@
 
 		  <!-- Wrapper for slides -->
 		  <div class="carousel-inner" role="listbox">
-		    <div class="item active"id="slide1" style="background: url(http://placehold.it/1920x605) no-repeat left center; background-size: cover;"> <!-- Ready for JS Injection -->
+		    <div class="item active"id="slide1" style="background: url(//placehold.it/1920x605) no-repeat left center; background-size: cover;"> <!-- Ready for JS Injection -->
 		      <div class="carousel-caption">
 				<div class="caption sfr slider-title">Breathtaking views</div>
 				<div class="caption sfl slider-subtitle">Relaxation in the Bay of Belfalas</div>
 				<a href="#" class="caption sfb btn btn-default btn-lg">Learn More</a>
 		      </div>
 		    </div>
-		    <div class="item" id="slide2" style="background: url(http://placehold.it/1920x605) no-repeat left center; background-size: cover;"> 
+		    <div class="item" id="slide2" style="background: url(//placehold.it/1920x605) no-repeat left center; background-size: cover;">
 		      <div class="carousel-caption">
 				<div class="caption sfr slider-title">The simple life</div>
 				<div class="caption sfl slider-subtitle">Lush gardens in Mordor</div>
@@ -143,38 +143,38 @@
 								<div id="regions">
 									<div class="item">
 										<a href="#">
-											<img src="http://placehold.it/194x194" alt=""  />
+											<img src="//placehold.it/194x194" alt=""  />
 											<h3>Rhovanion</h3>
 										</a>
 									</div>
 									<div class="item">
 										<a href="#">
-											<img src="http://placehold.it/194x194" alt="" />
+											<img src="//placehold.it/194x194" alt="" />
 											<h3>Eriador</h3>
 										</a>
 									</div>
 									<div class="item">
 										<a href="#">
-											<img src="http://placehold.it/194x194" alt=""  />
+											<img src="//placehold.it/194x194" alt=""  />
 											<h3>Bay of Belfalas</h3>
 										</a>
 									</div>
 									<div class="item">
 										<a href="#">
-											<img src="http://placehold.it/194x194" alt="" />
+											<img src="//placehold.it/194x194" alt="" />
 											<h3>Mordor</h3>
 										</a>
 									</div>
 
 									<div class="item">
 										<a href="#">
-											<img src="http://placehold.it/194x194" alt=""  />
+											<img src="//placehold.it/194x194" alt=""  />
 											<h3>The Southwest</h3>
 										</a>
 									</div>
 									<div class="item">
 										<a href="#">
-											<img src="http://placehold.it/194x194" alt="" />
+											<img src="//placehold.it/194x194" alt="" />
 											<h3>Arnor</h3>
 										</a>
 									</div>
@@ -228,7 +228,7 @@
 							<li class="col-md-12">
 								<div class="image">
 									<a href="blog-detail.html"></a>
-									<img alt="" src="http://placehold.it/100x100">
+									<img alt="" src="//placehold.it/100x100">
 								</div>
 								
 								<ul class="top-info">
@@ -240,7 +240,7 @@
 							<li class="col-md-12">
 								<div class="image">
 									<a href="blog-detail.html"></a>
-									<img alt="" src="http://placehold.it/100x100">
+									<img alt="" src="//placehold.it/100x100">
 								</div>
 								
 								<ul class="top-info">
@@ -252,7 +252,7 @@
 							<li class="col-md-12">
 								<div class="image">
 									<a href="blog-detail.html"></a>
-									<img alt="" src="http://placehold.it/100x100">
+									<img alt="" src="//placehold.it/100x100">
 								</div>
 								
 								<ul class="top-info">
@@ -264,7 +264,7 @@
 							<li class="col-md-12">
 								<div class="image">
 									<a href="blog-detail.html"></a>
-									<img alt="" src="http://placehold.it/100x100">
+									<img alt="" src="//placehold.it/100x100">
 								</div>
 								
 								<ul class="top-info">
@@ -282,7 +282,7 @@
 							<h2 class="section-title">Activity</h2>
 							<ul class="activity">
 								<li class="col-lg-12">
-									<a href="#"><img src="http://placehold.it/70x70" alt="" /></a>
+									<a href="#"><img src="//placehold.it/70x70" alt="" /></a>
 									<div class="info">										
 										<h5>Sam Minnée reviewed <a href="#">The House With No Windows</a></h4>
 										<p>Awesome solitary confinement, mate. Spot on. Sweet as.</p>
@@ -290,7 +290,7 @@
 									</div>
 								</li>
 								<li class="col-lg-12">
-									<a href="#"><img src="http://placehold.it/70x70" alt="" /></a>
+									<a href="#"><img src="//placehold.it/70x70" alt="" /></a>
 									<div class="info">
 										<h5>Ingo Schoomer asked a question about <a href="#">The Mistake by the Lake</a></h4>
 										<p>Has this house been unit tested?</p>

--- a/themes/one-ring/templates/Layout/PropertySearchPage.ss
+++ b/themes/one-ring/templates/Layout/PropertySearchPage.ss
@@ -35,7 +35,7 @@
 					<li class="col-md-12">
 						<div class="image">
 							<a href="blog-detail.html"></a>
-							<img src="http://placehold.it/100x100" alt="" />
+							<img src="//placehold.it/100x100" alt="" />
 						</div>
 						
 						<ul class="top-info">
@@ -47,7 +47,7 @@
 					<li class="col-md-12">
 						<div class="image">
 							<a href="blog-detail.html"></a>
-							<img src="http://placehold.it/100x100" alt="" />
+							<img src="//placehold.it/100x100" alt="" />
 						</div>
 						
 						<ul class="top-info">
@@ -59,7 +59,7 @@
 					<li class="col-md-12">
 						<div class="image">
 							<a href="blog-detail.html"></a>
-							<img src="http://placehold.it/100x100" alt="" />
+							<img src="//placehold.it/100x100" alt="" />
 						</div>
 						
 						<ul class="top-info">

--- a/themes/one-ring/templates/Layout/RegionsPage.ss
+++ b/themes/one-ring/templates/Layout/RegionsPage.ss
@@ -62,7 +62,7 @@
 							<li class="col-md-12">
 								<div class="image">
 									<a href="blog-detail.html"></a>
-									<img src="http://placehold.it/100x100" alt="" />
+									<img src="//placehold.it/100x100" alt="" />
 								</div>
 								
 								<ul class="top-info">
@@ -74,7 +74,7 @@
 							<li class="col-md-12">
 								<div class="image">
 									<a href="blog-detail.html"></a>
-									<img src="http://placehold.it/100x100" alt="" />
+									<img src="//placehold.it/100x100" alt="" />
 								</div>
 								
 								<ul class="top-info">
@@ -86,7 +86,7 @@
 							<li class="col-md-12">
 								<div class="image">
 									<a href="blog-detail.html"></a>
-									<img src="http://placehold.it/100x100" alt="" />
+									<img src="//placehold.it/100x100" alt="" />
 								</div>
 								
 								<ul class="top-info">


### PR DESCRIPTION
Now that our default is to force https on the demo, we are hitting mixed content warnings all over the place, and its particularly obvious on the fonts on the homepage. This should fix that.